### PR TITLE
test: refactored perp and price feed tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,137 +1,33 @@
-"""Tests for the nibiru-py package"""
-import dataclasses
-import os
-import unittest
-from typing import List
-
-import dotenv
-import pytest
-
-import nibiru
-from nibiru import common
-from nibiru.common import Coin
-
-dotenv.load_dotenv()
+"""Tests for the nibiru package"""
 
 
-@dataclasses.dataclass
-class TestConfig:
-    LCD_PORT = "1317"
-    GRPC_PORT = "9090"
-    VALIDATOR_MNEMONIC = os.environ["VALIDATOR_MNEMONIC"]
-    ORACLE_MNEMONIC = os.environ["ORACLE_MNEMONIC"]
-    NETWORK_INSECURE = os.environ["NETWORK_INSECURE"]
-    CHAIN_ID = os.environ["CHAIN_ID"]
-    HOST = os.environ["HOST"]
+def dict_keys_must_match(dict_: dict, keys: list[str]):
+    assert len(dict_.keys()) == len(keys)
+    for key in dict_.keys():
+        assert key in keys
 
 
-CONFIG = TestConfig()
-
-
-class ModuleTest(unittest.TestCase):
-    def setUp(self):
-        self.validator = get_val_node(get_network())
-        self.market = "ubtc:unusd"
-
-    def validate_tx_output(self, tx_output: dict):
-        """
-        Ensure the output of a transaction have the fields required and that the raw logs are properly parsed
-
-        Args:
-            tx_output (dict): The output of a transaction in a dictionary
-        """
-
-        self.assertIsInstance(tx_output, dict)
-        self.assertCountEqual(
-            tx_output.keys(),
-            [
-                'height',
-                'txhash',
-                'data',
-                'rawLog',
-                'logs',
-                'gasWanted',
-                'gasUsed',
-                'events',
-            ],
-        )
-        self.assertIsInstance(tx_output["rawLog"], list)
-
-    def create_new_agent_with_funds(
-        self, coins: List[Coin], mnemonic: str = None
-    ) -> nibiru.Sdk:
-        """
-        Create a new agent and fund it from the validator with some funds
-
-        Args:
-            coins (List[Coin]): A list of coins to fund
-
-        Returns:
-            (nibiru.Sdk): The new agent
-        """
-        tx_config = nibiru.TxConfig(tx_type=common.TxType.BLOCK, gas_multiplier=3)
-        agent = (
-            nibiru.Sdk.authorize(mnemonic)
-            .with_config(tx_config)
-            .with_network(get_network(), CONFIG.NETWORK_INSECURE)
-        )
-
-        result = self.validator.tx.msg_send(
-            self.validator.address, agent.address, coins
-        )
-        self.validate_tx_output(result)
-
-        return agent
-
-
-def get_network() -> nibiru.Network:
-    return nibiru.Network(
-        lcd_endpoint=f'http://{CONFIG.HOST}:{CONFIG.LCD_PORT}',
-        grpc_endpoint=f'{CONFIG.HOST}:{CONFIG.GRPC_PORT}',
-        chain_id=CONFIG.CHAIN_ID,
-        fee_denom='unibi',
-        env="local",
-    )
-
-
-def get_val_node(network: nibiru.Network) -> nibiru.Sdk:
-    tx_config = nibiru.TxConfig(tx_type=common.TxType.BLOCK)
-    return (
-        nibiru.Sdk.authorize(CONFIG.VALIDATOR_MNEMONIC)
-        .with_config(tx_config)
-        .with_network(network, CONFIG.NETWORK_INSECURE)
-    )
-
-
-def get_oracle_node(network: nibiru.Network) -> nibiru.Sdk:
-    tx_config = nibiru.TxConfig(tx_type=common.TxType.BLOCK, gas_multiplier=3)
-    return (
-        nibiru.Sdk.authorize(CONFIG.ORACLE_MNEMONIC)
-        .with_config(tx_config)
-        .with_network(network, CONFIG.NETWORK_INSECURE)
-    )
-
-
-@pytest.fixture
-def network() -> nibiru.Network:
+def transaction_must_succeed(tx_output: dict):
     """
-    Generate a network object
-
-    Returns:
-        nibiru.Network: Nibiru network object
-    """
-    return get_network()
-
-
-@pytest.fixture
-def val_node(network: nibiru.Network) -> nibiru.Sdk:
-    """
-    Create a authorized sdk with the validator mnemonic.
+    Ensure the output of a transaction have the fields required
+    and that the raw logs are properly parsed
 
     Args:
-        network (nibiru.Network): A nibiru network object
-
-    Returns:
-        nibiru.Sdk: The sdk object valid
+        tx_output (dict): The output of a transaction in a dictionary
     """
-    return get_val_node(network)
+
+    assert isinstance(tx_output, dict)
+    dict_keys_must_match(
+        tx_output,
+        [
+            "height",
+            "txhash",
+            "data",
+            "rawLog",
+            "logs",
+            "gasWanted",
+            "gasUsed",
+            "events",
+        ],
+    )
+    assert isinstance(tx_output["rawLog"], list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,36 @@ See "Scope: sharing fixtures across classes, modules, packages or session"
 Fixtures available:
 - network
 - val_node
+- oracle_node
+- agent_node
 """
 import os
 
 import pytest
+from dotenv import load_dotenv
 
 from nibiru import Network, Sdk
-from nibiru.common import TxConfig, TxType
+from nibiru.common import Coin, TxConfig, TxType
+
+
+def pytest_configure(config):
+    load_dotenv()
+
+    expected_env_vars = (
+        "HOST",
+        "GRPC_PORT",
+        "LCD_PORT",
+        "CHAIN_ID",
+        "VALIDATOR_MNEMONIC",
+        "ORACLE_MNEMONIC",
+    )
+    for var in expected_env_vars:
+        if not os.getenv(var):
+            raise ValueError(f"Environment variable {var} is missing!")
+
+    pytest.VALIDATOR_MNEMONIC = os.getenv("VALIDATOR_MNEMONIC")
+    pytest.ORACLE_MNEMONIC = os.getenv("ORACLE_MNEMONIC")
+    pytest.NETWORK_INSECURE = os.getenv("NETWORK_INSECURE") != "false"
 
 
 @pytest.fixture
@@ -26,14 +49,31 @@ def network() -> Network:
 @pytest.fixture
 def val_node(network: Network) -> Sdk:
     tx_config = TxConfig(tx_type=TxType.BLOCK)
-    network_insecure: bool = True
-    env_var_name = "VALIDATOR_MNEMONIC"
-    val_mnemonic = os.getenv(env_var_name)
-    if val_mnemonic is None:
-        raise Exception(f"Missing environment variable {env_var_name}")
 
     return (
-        Sdk.authorize(val_mnemonic)
+        Sdk.authorize(pytest.VALIDATOR_MNEMONIC)
         .with_config(tx_config)
-        .with_network(network, network_insecure)
+        .with_network(network, pytest.NETWORK_INSECURE)
+    )
+
+
+@pytest.fixture
+def oracle_agent(network: Network, val_node: Sdk) -> Sdk:
+    tx_config = TxConfig(tx_type=TxType.BLOCK, gas_multiplier=3)
+    agent = (
+        Sdk.authorize(os.getenv("ORACLE_MNEMONIC"))
+        .with_config(tx_config)
+        .with_network(network, pytest.NETWORK_INSECURE)
+    )
+    val_node.tx.msg_send(val_node.address, agent.address, [Coin(10000, "unibi")])
+    return agent
+
+
+@pytest.fixture
+def agent(network: Network) -> Sdk:
+    tx_config = TxConfig(tx_type=TxType.BLOCK, gas_multiplier=3)
+    return (
+        Sdk.authorize()
+        .with_config(tx_config)
+        .with_network(network, pytest.NETWORK_INSECURE)
     )

--- a/tests/perp_test.py
+++ b/tests/perp_test.py
@@ -9,88 +9,87 @@ from tests import dict_keys_must_match, transaction_must_succeed
 PRECISION = 6
 
 
-class TestPerp:
-    def test_open_close_position(self, val_node, agent):
-        """
-        Open a position and ensure output is correct
-        """
-        pair = "ubtc:unusd"
+def test_open_close_position(val_node, agent):
+    """
+    Open a position and ensure output is correct
+    """
+    pair = "ubtc:unusd"
 
-        # Funding agent
-        val_node.tx.msg_send(
-            val_node.address, agent.address, [Coin(10000, "unibi"), Coin(100, "unusd")]
-        )
+    # Funding agent
+    val_node.tx.msg_send(
+        val_node.address, agent.address, [Coin(10000, "unibi"), Coin(100, "unusd")]
+    )
 
-        # Exception must be raised when requesting not existing position
-        with raises(_InactiveRpcError, match="no position found"):
-            agent.query.perp.trader_position(trader=agent.address, token_pair=pair)
+    # Exception must be raised when requesting not existing position
+    with raises(_InactiveRpcError, match="no position found"):
+        agent.query.perp.trader_position(trader=agent.address, token_pair=pair)
 
-        # Transaction open_position must succeed
-        tx_output = agent.tx.perp.open_position(
-            sender=agent.address,
-            token_pair=pair,
-            side=common.Side.BUY,
-            quote_asset_amount=10,
-            leverage=10,
-            base_asset_amount_limit=0,
-        )
-        transaction_must_succeed(tx_output)
+    # Transaction open_position must succeed
+    tx_output = agent.tx.perp.open_position(
+        sender=agent.address,
+        token_pair=pair,
+        side=common.Side.BUY,
+        quote_asset_amount=10,
+        leverage=10,
+        base_asset_amount_limit=0,
+    )
+    transaction_must_succeed(tx_output)
 
-        # Trader position must be a dict with specific keys
-        position_res = agent.query.perp.trader_position(
-            trader=agent.address, token_pair=pair
-        )
-        dict_keys_must_match(
-            position_res,
-            [
-                "block_number",
-                "margin_ratio_index",
-                "margin_ratio_mark",
-                "position",
-                "position_notional",
-                "unrealized_pnl",
-            ],
-        )
-        # Margin ratio must be ~10%
-        assert position_res["margin_ratio_mark"] == approx(0.1, PRECISION)
+    # Trader position must be a dict with specific keys
+    position_res = agent.query.perp.trader_position(
+        trader=agent.address, token_pair=pair
+    )
+    dict_keys_must_match(
+        position_res,
+        [
+            "block_number",
+            "margin_ratio_index",
+            "margin_ratio_mark",
+            "position",
+            "position_notional",
+            "unrealized_pnl",
+        ],
+    )
+    # Margin ratio must be ~10%
+    assert position_res["margin_ratio_mark"] == approx(0.1, PRECISION)
 
-        position = position_res["position"]
-        assert position["margin"] == 10.0
-        assert position["open_notional"] == 100.0
-        assert position["size"] == approx(0.005, PRECISION)
+    position = position_res["position"]
+    assert position["margin"] == 10.0
+    assert position["open_notional"] == 100.0
+    assert position["size"] == approx(0.005, PRECISION)
 
-        # Transaction add_margin must succeed
-        tx_output = agent.tx.perp.add_margin(
-            sender=agent.address,
-            token_pair=pair,
-            margin=Coin(10, "unusd"),
-        )
-        transaction_must_succeed(tx_output)
+    # Transaction add_margin must succeed
+    tx_output = agent.tx.perp.add_margin(
+        sender=agent.address,
+        token_pair=pair,
+        margin=Coin(10, "unusd"),
+    )
+    transaction_must_succeed(tx_output)
 
-        # Margin must increase. 10 + 10 = 20
-        position = agent.query.perp.trader_position(
-            trader=agent.address, token_pair=pair
-        )["position"]
-        assert position["margin"] == 20.0
+    # Margin must increase. 10 + 10 = 20
+    position = agent.query.perp.trader_position(trader=agent.address, token_pair=pair)[
+        "position"
+    ]
+    assert position["margin"] == 20.0
 
-        # Transaction remove_margin must succeed
-        tx_output = agent.tx.perp.remove_margin(
-            sender=agent.address,
-            token_pair=pair,
-            margin=common.Coin(5, "unusd"),
-        )
-        transaction_must_succeed(tx_output)
+    # Transaction remove_margin must succeed
+    tx_output = agent.tx.perp.remove_margin(
+        sender=agent.address,
+        token_pair=pair,
+        margin=common.Coin(5, "unusd"),
+    )
+    transaction_must_succeed(tx_output)
 
-        # Margin must decrease. 20 - 5 = 15
-        position = agent.query.perp.trader_position(
-            trader=agent.address, token_pair=pair
-        )["position"]
-        assert position["margin"] == 15.0
+    # Margin must decrease. 20 - 5 = 15
+    position = agent.query.perp.trader_position(trader=agent.address, token_pair=pair)[
+        "position"
+    ]
+    assert position["margin"] == 15.0
 
-        # Transaction close_position must succeed
-        tx_output = agent.tx.perp.close_position(sender=agent.address, token_pair=pair)
-        transaction_must_succeed(tx_output)
+    # Transaction close_position must succeed
+    tx_output = agent.tx.perp.close_position(sender=agent.address, token_pair=pair)
+    transaction_must_succeed(tx_output)
 
-        # Exception must be raised when querying closed position
-        with raises(_InactiveRpcError, match="no position found"):
-            agent.query.perp.trader_position(trader=agent.address, token_pair=pair)
+    # Exception must be raised when querying closed position
+    with raises(_InactiveRpcError, match="no position found"):
+        agent.query.perp.trader_position(trader=agent.address, token_pair=pair)

--- a/tests/pricefeed_test.py
+++ b/tests/pricefeed_test.py
@@ -4,71 +4,64 @@ from datetime import datetime, timedelta
 from tests import dict_keys_must_match, transaction_must_succeed
 
 
-class TestPricefeed:
-    def test_post_prices(self, oracle_agent):
+def test_post_prices(oracle_agent):
 
-        # Market unibi:unusd must be in the list of pricefeed markets
-        markets_output = oracle_agent.query.pricefeed.markets()
-        assert isinstance(markets_output, dict)
-        assert any(
-            [market["pair_id"] == "unibi:unusd" for market in markets_output["markets"]]
-        )
+    # Market unibi:unusd must be in the list of pricefeed markets
+    markets_output = oracle_agent.query.pricefeed.markets()
+    assert isinstance(markets_output, dict)
+    assert any(
+        [market["pair_id"] == "unibi:unusd" for market in markets_output["markets"]]
+    )
 
-        # Oracle must be in the list of unibi:unusd market oracles
-        unibi_unusd_market = next(
-            market
-            for market in markets_output["markets"]
-            if market["pair_id"] == "unibi:unusd"
-        )
-        assert oracle_agent.address in unibi_unusd_market["oracles"]
+    # Oracle must be in the list of unibi:unusd market oracles
+    unibi_unusd_market = next(
+        market
+        for market in markets_output["markets"]
+        if market["pair_id"] == "unibi:unusd"
+    )
+    assert oracle_agent.address in unibi_unusd_market["oracles"]
 
-        # Transaction post_price must succeed
-        tx_output = oracle_agent.tx.pricefeed.post_price(
-            oracle_agent.address,
-            token0="unibi",
-            token1="unusd",
-            price=10,
-            expiry=datetime.utcnow() + timedelta(hours=1),
-        )
-        transaction_must_succeed(tx_output)
+    # Transaction post_price must succeed
+    tx_output = oracle_agent.tx.pricefeed.post_price(
+        oracle_agent.address,
+        token0="unibi",
+        token1="unusd",
+        price=10,
+        expiry=datetime.utcnow() + timedelta(hours=1),
+    )
+    transaction_must_succeed(tx_output)
 
-        # Repeating post_price transaction.
-        # Otherwise, getting "All input prices are expired" on query.pricefeed.price()
-        tx_output = oracle_agent.tx.pricefeed.post_price(
-            oracle_agent.address,
-            token0="unibi",
-            token1="unusd",
-            price=10,
-            expiry=datetime.utcnow() + timedelta(hours=1),
-        )
-        transaction_must_succeed(tx_output)
+    # Repeating post_price transaction.
+    # Otherwise, getting "All input prices are expired" on query.pricefeed.price()
+    tx_output = oracle_agent.tx.pricefeed.post_price(
+        oracle_agent.address,
+        token0="unibi",
+        token1="unusd",
+        price=10,
+        expiry=datetime.utcnow() + timedelta(hours=1),
+    )
+    transaction_must_succeed(tx_output)
 
-        # Raw prices must exist after post_price transaction
-        raw_prices = oracle_agent.query.pricefeed.raw_prices("unibi:unusd")[
-            "raw_prices"
-        ]
-        assert len(raw_prices) >= 1
+    # Raw prices must exist after post_price transaction
+    raw_prices = oracle_agent.query.pricefeed.raw_prices("unibi:unusd")["raw_prices"]
+    assert len(raw_prices) >= 1
 
-        # Raw price must be a dict with specific keys
-        raw_price = raw_prices[0]
-        dict_keys_must_match(
-            raw_price, ['expiry', 'oracle_address', 'pair_id', 'price']
-        )
+    # Raw price must be a dict with specific keys
+    raw_price = raw_prices[0]
+    dict_keys_must_match(raw_price, ['expiry', 'oracle_address', 'pair_id', 'price'])
 
-        # Price feed params must be a dict with specific keys
-        price_feed_params = oracle_agent.query.pricefeed.params()["params"]
-        dict_keys_must_match(price_feed_params, ['pairs', 'twap_lookback_window'])
+    # Price feed params must be a dict with specific keys
+    price_feed_params = oracle_agent.query.pricefeed.params()["params"]
+    dict_keys_must_match(price_feed_params, ['pairs', 'twap_lookback_window'])
 
-        # Unibi price object must be a dict with specific keys
-        unibi_price = oracle_agent.query.pricefeed.price("unibi:unusd")["price"]
-        dict_keys_must_match(unibi_price, ["pair_id", "price"])
+    # Unibi price object must be a dict with specific keys
+    unibi_price = oracle_agent.query.pricefeed.price("unibi:unusd")["price"]
+    dict_keys_must_match(unibi_price, ["pair_id", "price"])
 
-        # At least one pair in prices must be unibi:unusd
-        prices = oracle_agent.query.pricefeed.prices()["prices"]
-        assert any([price["pair_id"] == "unibi:unusd" for price in prices])
+    # At least one pair in prices must be unibi:unusd
+    prices = oracle_agent.query.pricefeed.prices()["prices"]
+    assert any([price["pair_id"] == "unibi:unusd" for price in prices])
 
-        # Unibi price object must be a dict with specific keys
-        unibi_price = next(
-            price for price in prices if price["pair_id"] == "unibi:unusd"
-        )
-        dict_keys_must_match(unibi_price, ["pair_id", "price"])
+    # Unibi price object must be a dict with specific keys
+    unibi_price = next(price for price in prices if price["pair_id"] == "unibi:unusd")
+    dict_keys_must_match(unibi_price, ["pair_id", "price"])


### PR DESCRIPTION
- Replaced Unittest with standard pytest approach https://docs.pytest.org/en/7.1.x/
- Extracted all "aux" methods into fixtures
- Removed duplicated code
- Added `conftest.pytest_configure()` which loads and validates the environment
- Refactored `perp` tests
- Refartored `pricefeed` tests