### PR TITLE
Use grpcio 1.47> instead of 1.48 (which was yanked)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -239,7 +239,7 @@ cython = ["cython"]
 
 [[package]]
 name = "distlib"
-version = "0.3.5"
+version = "0.3.6"
 description = "Distribution utilities"
 category = "main"
 optional = false
@@ -727,7 +727,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "types-protobuf"
-version = "3.19.22"
+version = "3.20.1"
 description = "Typing stubs for protobuf"
 category = "main"
 optional = false
@@ -810,7 +810,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6d121bafb0202b6c13cb0ee71ba7b36761fcc5c2e8e30530e1eb8bc7569c328a"
+content-hash = "60f20cc223f5ba9d39a51bfef0c67ec26adc16e28c44ce8a6395ab76ca287566"
 
 [metadata.files]
 aiocron = [
@@ -1166,8 +1166,8 @@ cytoolz = [
     {file = "cytoolz-0.12.0.tar.gz", hash = "sha256:c105b05f85e03fbcd60244375968e62e44fe798c15a3531c922d531018d22412"},
 ]
 distlib = [
-    {file = "distlib-0.3.5-py2.py3-none-any.whl", hash = "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"},
-    {file = "distlib-0.3.5.tar.gz", hash = "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe"},
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
 ]
 ecdsa = [
     {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
@@ -1619,8 +1619,8 @@ toolz = [
     {file = "toolz-0.12.0.tar.gz", hash = "sha256:88c570861c440ee3f2f6037c4654613228ff40c93a6c25e0eba70d17282c6194"},
 ]
 types-protobuf = [
-    {file = "types-protobuf-3.19.22.tar.gz", hash = "sha256:d2b26861b0cb46a3c8669b0df507b7ef72e487da66d61f9f3576aa76ce028a83"},
-    {file = "types_protobuf-3.19.22-py3-none-any.whl", hash = "sha256:d291388678af91bb045fafa864f142dc4ac22f5d4cdca097c7d8d8a32fa9b3ab"},
+    {file = "types-protobuf-3.20.1.tar.gz", hash = "sha256:36e3426476e373da6f2bb8a81a1194478cd1f33813a4e254849146d28c450e00"},
+    {file = "types_protobuf-3.20.1-py3-none-any.whl", hash = "sha256:b0bc0ffde2a339ee25c4b47e9dd515010153ad80c21d16fb57a2429987579801"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-grpcio = "^1.48.0"
+grpcio = "^1.47.0"
 asyncio = "^3.4.3"
 bech32 = "^1.2.0"
 python-dotenv = "^0.20.0"


### PR DESCRIPTION
v1.47 was yanked for security reason which does not really affect us (https://pypi.org/project/grpcio/#history). This is still annoying when we want to install with pip nibiru since it cannot find the requriements and fails: 

```shell
Collecting nibiru
  Using cached nibiru-0.3.0-py3-none-any.whl (32 kB)
Collecting protobuf==3.20.1
  Using cached protobuf-3.20.1-cp310-cp310-macosx_10_9_universal2.whl (962 kB)
Collecting aiohttp<4.0.0,>=3.8.1
  Downloading aiohttp-3.8.1-cp310-cp310-macosx_11_0_arm64.whl (552 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 552.5/552.5 kB 5.2 MB/s eta 0:00:00[31m6.5 MB/s eta 0:00:01
Collecting coincurve<18.0.0,>=17.0.0
  Downloading coincurve-17.0.0-cp310-cp310-macosx_11_0_arm64.whl (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 8.4 MB/s eta 0:00:000m eta 0:00:010:01
Collecting ecdsa<0.19.0,>=0.18.0
  Using cached ecdsa-0.18.0-py2.py3-none-any.whl (142 kB)
Collecting nibiru
  Downloading nibiru-0.2.0-py3-none-any.whl (32 kB)
  Using cached nibiru-0.1.1-py3-none-any.whl (32 kB)
  Using cached nibiru-0.1.0-py3-none-any.whl (31 kB)
  Using cached nibiru-0.0.18-py3-none-any.whl (31 kB)
  Using cached nibiru-0.0.17-py3-none-any.whl (547 kB)
Collecting pysha3<2.0.0,>=1.0.2
  Using cached pysha3-1.0.2.tar.gz (829 kB)
  Preparing metadata (setup.py) ... done
Collecting nibiru
  Using cached nibiru-0.0.16-py3-none-any.whl (545 kB)
ERROR: Cannot install nibiru==0.0.16, nibiru==0.0.17, nibiru==0.0.18, nibiru==0.1.0, nibiru==0.1.1, nibiru==0.2.0 and nibiru==0.3.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    nibiru 0.3.0 depends on grpcio<2.0.0 and >=1.48.0
    nibiru 0.2.0 depends on grpcio<2.0.0 and >=1.48.0
    nibiru 0.1.1 depends on grpcio<2.0.0 and >=1.48.0
    nibiru 0.1.0 depends on grpcio<2.0.0 and >=1.48.0
    nibiru 0.0.18 depends on grpcio<2.0.0 and >=1.48.0
    nibiru 0.0.17 depends on grpcio<2.0.0 and >=1.48.0
    nibiru 0.0.16 depends on grpcio<2.0.0 and >=1.48.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```