### PR TITLE
feat: get block by height

### DIFF
--- a/nibiru/client.py
+++ b/nibiru/client.py
@@ -66,6 +66,12 @@ class GrpcClient:
         block = self.get_latest_block()
         self.timeout_height = block.block.header.height + DEFAULT_TIMEOUTHEIGHT
 
+    def get_block_by_height(
+        self, height: int
+    ) -> tendermint_query.GetBlockByHeightResponse:
+        req = tendermint_query.GetBlockByHeightRequest(height=height)
+        return self.stubCosmosTendermint.GetBlockByHeight(req)
+
     # default client methods
     def get_latest_block(self) -> tendermint_query.GetLatestBlockResponse:
         req = tendermint_query.GetLatestBlockRequest()

--- a/tests/bank_test.py
+++ b/tests/bank_test.py
@@ -49,3 +49,8 @@ def test_send_single_msg(val_node: nibiru.Sdk, agent: nibiru.Sdk):
         "nibid tx bank send - single msgs:\n" + tests.format_response(tx_output)
     )
     tests.transaction_must_succeed(tx_output)
+
+
+def test_send_single_msg(val_node: nibiru.Sdk, agent: nibiru.Sdk):
+    val_node.query.stubCosmosTendermint.GetBlockByHeight()
+    ...

--- a/tests/chain_info_test.py
+++ b/tests/chain_info_test.py
@@ -33,3 +33,22 @@ def test_query_perp_params(val_node: Sdk):
         "twapLookbackWindow",
     ]
     assert all([(param_name in params) for param_name in perp_param_names])
+
+
+def test_block_getters(agent: Sdk):
+    """Tests queries from the Tendemint gRPC channel
+    - GetBlockByHeight
+    - GetLatestBlock
+    """
+
+    block_by_height_resp = agent.query.get_block_by_height(2)
+    latest_block_resp = agent.query.get_latest_block()
+    block_id_fields: List[str] = ["hash", "part_set_header"]
+    block_fields: List[str] = ["data", "evidence", "header", "last_commit"]
+    for block_resp in [block_by_height_resp, latest_block_resp]:
+        assert all(
+            [hasattr(block_resp.block_id, attr) for attr in block_id_fields]
+        ), "missing attributes on the 'block_id' field"
+        assert all(
+            [hasattr(block_resp.block, attr) for attr in block_fields]
+        ), "missing attributes on the 'block' field"


### PR DESCRIPTION


### Context

- Related: https://github.com/NibiruChain/heart-monitor/issues/11

```python
agent: nibiru.Sdk 
block_resp = agent.query.stubCosmosTendermint.GetBlockByHeight(2)
```

The block timestamp is available from `block_resp.block.header.time`.

