### PR TITLE
Catching websocket tx event exceptions

### DIFF
--- a/nibiru/websocket.py
+++ b/nibiru/websocket.py
@@ -2,6 +2,7 @@ import base64
 import json
 import threading
 import time
+from json import JSONDecodeError
 from multiprocessing import Queue
 from typing import List
 
@@ -125,7 +126,11 @@ class NibiruWebsocket:
         block_height = int(log["data"]["value"]["TxResult"]["height"])
         tx_hash = events["tx.hash"][0]
 
-        events = json.loads(log["data"]["value"]["TxResult"]["result"]["log"])[0]
+        try:
+            events = json.loads(log["data"]["value"]["TxResult"]["result"]["log"])[0]
+        except JSONDecodeError:
+            # failed to execute message
+            return
 
         for event in events["events"]:
             self._handle_event(block_height, tx_hash, event)


### PR DESCRIPTION
Driven by crashed SDK websocket upon failing execution of Staking unbond event.

Instead of JSON event it contains string: `'failed to execute message; message index: 0: too many unbonding delegation entries for (delegator, validator) tuple'`