### PR TITLE
Websocket Tx fail queue

### DIFF
--- a/nibiru/websocket.py
+++ b/nibiru/websocket.py
@@ -27,7 +27,7 @@ class NibiruWebsocket:
         self,
         network: Network,
         captured_events_type: List[EventType] = [],
-        tx_fail_queue=None,
+        tx_fail_queue: Queue = None,
     ):
         """
         The nibiru listener provides an interface to easily connect and handle subscription to the events of a nibiru

--- a/nibiru/websocket.py
+++ b/nibiru/websocket.py
@@ -137,7 +137,9 @@ class NibiruWebsocket:
             # failed to execute message
             raw_log = log["data"]["value"]["TxResult"]["result"]["log"]
             if self.tx_fail_queue:
-                self.tx_fail_queue.put(raw_log)
+                self.tx_fail_queue.put(
+                    {"block_height": block_height, "tx_hash": tx_hash, "error": raw_log}
+                )
             self.logger.debug(f"Failed parsing events log: {raw_log}. {ex}")
             return
 

--- a/nibiru/websocket.py
+++ b/nibiru/websocket.py
@@ -20,12 +20,14 @@ ERROR_TIMEOUT_SLEEP = 3
 
 class NibiruWebsocket:
     queue: Queue = None
+    tx_fail_queue: Queue = None
     captured_events_type: List[List[str]]
 
     def __init__(
         self,
         network: Network,
         captured_events_type: List[EventType] = [],
+        tx_fail_queue=None,
     ):
         """
         The nibiru listener provides an interface to easily connect and handle subscription to the events of a nibiru
@@ -35,7 +37,8 @@ class NibiruWebsocket:
         self.websocket_url = network.websocket_endpoint
         if self.websocket_url is None:
             raise ValueError(
-                "No websocket endpoint provided. Construct the network object setting up the "
+                "No websocket endpoint provided. "
+                "Construct the network object setting up the "
                 "`websocket_endpoint` endpoint"
             )
 
@@ -45,6 +48,8 @@ class NibiruWebsocket:
             for captured_event in captured_events_type
         }
         self.queue = Queue()
+        if tx_fail_queue:
+            self.tx_fail_queue = tx_fail_queue
         self.logger = init_logger("ws-logger")
 
     def start(self):
@@ -131,6 +136,8 @@ class NibiruWebsocket:
         except JSONDecodeError as ex:
             # failed to execute message
             raw_log = log["data"]["value"]["TxResult"]["result"]["log"]
+            if self.tx_fail_queue:
+                self.tx_fail_queue.put(raw_log)
             self.logger.debug(f"Failed parsing events log: {raw_log}. {ex}")
             return
 

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -1,10 +1,11 @@
 import time
 from datetime import datetime, timedelta
+from multiprocessing import Queue
 from typing import List
 
 import nibiru
 import nibiru.msg
-from nibiru import Network, common
+from nibiru import Network, Sdk, Transaction, common
 from nibiru.event_specs import EventCaptured
 from nibiru.websocket import EventType, NibiruWebsocket
 from tests import LOGGER
@@ -105,3 +106,53 @@ def test_websocket_listen(val_node: nibiru.Sdk, network: Network):
     ]
 
     assert not missing_events, f"Missing events: {missing_events}"
+
+
+def test_websocket_tx_fail_queue(val_node: Sdk, network: Network):
+    """
+    Try executing failing TXs and get errors from tx_fail_queue
+    """
+    tx_fail_queue = Queue()
+
+    nibiru_websocket = NibiruWebsocket(
+        network,
+        [EventType.PositionChangedEvent],
+        tx_fail_queue,
+    )
+    nibiru_websocket.start()
+    time.sleep(1)
+
+    # Send failing closing transaction without simulation
+    val_node.tx.client.sync_timeout_height()
+    address = val_node.tx.get_address_info()
+    tx = (
+        Transaction()
+        .with_messages(
+            [
+                nibiru.msg.MsgClosePosition(
+                    sender=val_node.address,
+                    token_pair="abc:def",
+                ).to_pb()
+            ]
+        )
+        .with_sequence(address.get_sequence())
+        .with_account_num(address.get_number())
+        .with_chain_id(network.chain_id)
+        .with_signer(val_node.tx.priv_key)
+    )
+    val_node.tx.execute_tx(tx, 300000)
+
+    time.sleep(3)
+
+    tx_fail_queue.put(None)
+    fail_event_found = False
+
+    while True:
+        event = tx_fail_queue.get()
+        if event is None:
+            break
+        if "failed to execute message" and "no position found" in event:
+            fail_event_found = True
+            break
+
+    assert fail_event_found, "Transaction failure not captured"

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -151,7 +151,7 @@ def test_websocket_tx_fail_queue(val_node: Sdk, network: Network):
         event = tx_fail_queue.get()
         if event is None:
             break
-        if "failed to execute message" and "no position found" in event:
+        if "failed to execute message" and "no position found" in event["error"]:
             fail_event_found = True
             break
 


### PR DESCRIPTION
SDK user could now submit an optional queue to the websocket to capture failed transactions errors like this:

```py
tx_fail_queue = Queue()

nibiru_websocket = NibiruWebsocket(
    network,
    [EventType.PositionChangedEvent],
    tx_fail_queue,
)
```

Now if chain detects failed transaction queue gets a value:

```json
{
   "block_height": 61109,
   "tx_hash": "383F3C2D9EE0A28EF2954ADE2A83FF3EA39F21B739DAEF8644BA0BA833AA651F", 
   "error": "failed to execute message; message index: 0: no position found"
}
```