### PR TITLE
chore: version update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nibiru"
-version = "0.16.2"
+version = "0.16.3"
 description = "Python SDK for interacting with Nibiru."
 authors = ["Nibiru Chain <dev@nibiru.fi>"]
 license = "MIT"


### PR DESCRIPTION
workaround for pypi deloy