### PR TITLE
feat: make collab notebook retry when failing

### DIFF
--- a/examples/collab_notebook.ipynb
+++ b/examples/collab_notebook.ipynb
@@ -84,15 +84,29 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "response = requests.post(\n",
-    "    \"https://faucet.testnet-2.nibiru.fi/\",\n",
-    "    json={\n",
-    "        \"address\": agent.address,\n",
-    "        \"coins\": [\"10000000unibi\", \"100000000000unusd\"],\n",
-    "    },\n",
-    ")\n",
-    "print(response.content)"
+    "try_count = 0\n",
+    "while not agent.query.get_bank_balances(agent.address)[\"balances\"]:\n",
+    "    try_count += 1\n",
+    "    if try_count > 10:\n",
+    "        raise Exception(\"unable to get funds from the faucet...\")\n",
+    "\n",
+    "    response = requests.post(\n",
+    "        \"https://faucet.testnet-2.nibiru.fi/\",\n",
+    "        json={\n",
+    "            \"address\": agent.address,\n",
+    "            \"coins\": [\"10000000unibi\", \"100000000000unusd\"],\n",
+    "        },\n",
+    "    )\n",
+    "    print(response.content)\n",
+    "    time.sleep(10)\n"
    ]
   },
   {
@@ -108,7 +122,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "time.sleep(10)\n",
     "print(agent.query.get_bank_balances(agent.address))"
    ]
   },
@@ -130,7 +143,7 @@
     "        sender=agent.address,\n",
     "        pair=\"ubtc:unusd\",\n",
     "        side=nibiru.Side.BUY,\n",
-    "        quote_asset_amount=10,\n",
+    "        quote_asset_amount=1,\n",
     "        leverage=10,\n",
     "        base_asset_amount_limit=0,\n",
     "    )\n",
@@ -172,7 +185,7 @@
     "    nibiru.msg.perp.MsgAddMargin(\n",
     "        sender=agent.address,\n",
     "        pair=pair,\n",
-    "        margin=nibiru.Coin(10, \"unusd\"),\n",
+    "        margin=nibiru.Coin(1, \"unusd\"),\n",
     "    )\n",
     ")\n"
    ]
@@ -203,7 +216,7 @@
     "    nibiru.msg.perp.MsgRemoveMargin(\n",
     "        sender=agent.address,\n",
     "        pair=pair,\n",
-    "        margin=nibiru.Coin(5, \"unusd\"),\n",
+    "        margin=nibiru.Coin(1, \"unusd\"),\n",
     "    )\n",
     ")\n"
    ]
@@ -274,19 +287,19 @@
     "            sender=agent.address,\n",
     "            pair=\"ubtc:unusd\",\n",
     "            side=nibiru.Side.BUY,\n",
-    "            quote_asset_amount=100,\n",
+    "            quote_asset_amount=2,\n",
     "            base_asset_amount_limit=0,\n",
     "            leverage=5,\n",
     "        ),\n",
     "        nibiru.msg.perp.MsgRemoveMargin(\n",
     "            sender=agent.address,\n",
     "            pair=pair,\n",
-    "            margin=nibiru.Coin(5, \"unusd\"),\n",
+    "            margin=nibiru.Coin(1, \"unusd\"),\n",
     "        ),\n",
     "        nibiru.msg.bank.MsgSend(\n",
     "            from_address=agent.address,\n",
     "            to_address=\"nibi1g39urhrvycnrc8y99xmqm7udr6fltjs3stnkxp\", # Random address\n",
-    "            coins=[nibiru.Coin(5, \"unusd\")],\n",
+    "            coins=[nibiru.Coin(1, \"unusd\")],\n",
     "        ),\n",
     "        nibiru.msg.perp.MsgClosePosition(sender=agent.address, pair=pair),\n",
     "    ]\n",
@@ -296,18 +309,26 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nibi",
+   "display_name": "nibiru-py-k3GTQe1V",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10.4"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "23c82724f6800107d27a1bc097df076b7f523b299f39e774e7f2b8b0c7154a18"
+    "hash": "b332d8d531602c345a00d4444116ed5f8f40664116717716e6e6b2e5640a7573"
    }
   }
  },


### PR DESCRIPTION
Sometimes testnet faucet fails to send fund for account sequence mismatch error. This changes makes the collab example notebook retry 10 time before raising an error if the funds were not acquired.