### PR TITLE
refactor: got rid of sender parameter in tx messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ print(client.query.get_bank_balances(client.address))
 ```python
 output = client.tx.execute_msgs(
     Msg.perp.open_position(
-        sender=client.address,
         pair=pair,
         is_long=True,
         quote_asset_amount=10,

--- a/examples/2- My first transaction.ipynb
+++ b/examples/2- My first transaction.ipynb
@@ -123,7 +123,6 @@
    "source": [
     "output = client.tx.execute_msgs(\n",
     "    Msg.perp.open_position(\n",
-    "        sender=client.address,\n",
     "        pair=pair,\n",
     "        is_long=True,\n",
     "        quote_asset_amount=10,\n",

--- a/examples/colab_notebook.ipynb
+++ b/examples/colab_notebook.ipynb
@@ -76,7 +76,6 @@
    "source": [
     "output = client.tx.execute_msgs(\n",
     "    Msg.perp.open_position(\n",
-    "        sender=client.address,\n",
     "        pair=pair,\n",
     "        is_long=True,\n",
     "        quote_asset_amount=10,\n",
@@ -144,7 +143,6 @@
    "source": [
     "output = client.tx.execute_msgs(\n",
     "    Msg.perp.add_margin(\n",
-    "        sender=client.address,\n",
     "        pair=pair,\n",
     "        margin=Coin(1, \"unusd\"),\n",
     "    )\n",
@@ -167,7 +165,6 @@
    "source": [
     "output = client.tx.execute_msgs(\n",
     "    Msg.perp.remove_margin(\n",
-    "        sender=client.address,\n",
     "        pair=pair,\n",
     "        margin=Coin(1, \"unusd\")\n",
     "    )\n",
@@ -190,7 +187,6 @@
    "source": [
     "output = client.tx.execute_msgs(\n",
     "    Msg.perp.close_position(\n",
-    "        sender=client.address,\n",
     "        pair=pair,\n",
     "    )\n",
     ")\n",
@@ -232,7 +228,6 @@
     "output = client.tx.execute_msgs(\n",
     "    [\n",
     "        Msg.perp.open_position(\n",
-    "            sender=client.address,\n",
     "            pair=pair,\n",
     "            is_long=True,\n",
     "            quote_asset_amount=10,\n",
@@ -240,12 +235,10 @@
     "            base_asset_amount_limit=0,\n",
     "        ),\n",
     "        Msg.perp.add_margin(\n",
-    "            sender=client.address,\n",
     "            pair=pair,\n",
     "            margin=Coin(1, \"unusd\"),\n",
     "        ),\n",
     "        Msg.perp.close_position(\n",
-    "            sender=client.address,\n",
     "            pair=pair,\n",
     "        ),\n",
     "    ]\n",

--- a/nibiru/msg/bank.py
+++ b/nibiru/msg/bank.py
@@ -15,7 +15,6 @@ class MsgsBank:
 
     @staticmethod
     def send(
-        from_address: str,
         to_address: str,
         coins: Union[Coin, List[Coin]],
     ) -> 'MsgSend':
@@ -23,14 +22,13 @@ class MsgsBank:
         Send tokens from one account to another
 
         Attributes:
-            from_address (str): The address of the sender
             to_address (str): The address of the receiver
             coins (List[Coin]): The list of coins to send
 
         Returns:
             MsgSend: PythonMsg corresponding to the 'cosmos.bank.v1beta1.MsgSend' message
         """
-        return MsgSend(from_address=from_address, to_address=to_address, coins=coins)
+        return MsgSend(to_address=to_address, coins=coins)
 
 
 @dataclasses.dataclass
@@ -40,16 +38,14 @@ class MsgSend(PythonMsg):
     'cosmos.bank.v1beta1.MsgSend' message.
 
     Attributes:
-        from_address (str): The address of the sender
         to_address (str): The address of the receiver
         coins (Union[Coin, List[Coin]]): The list of coins to send
     """
 
-    from_address: str
     to_address: str
     coins: Union[Coin, List[Coin]]
 
-    def to_pb(self) -> pb.MsgSend:
+    def to_pb(self, sender: str) -> pb.MsgSend:
         """
         Returns the Message as protobuf object.
 
@@ -62,7 +58,7 @@ class MsgSend(PythonMsg):
             coins = [self.coins]
 
         return pb.MsgSend(
-            from_address=self.from_address,
+            from_address=sender,
             to_address=self.to_address,
-            amount=[coin._generate_proto_object() for coin in coins],
+            amount=[coin.to_pb() for coin in coins],
         )

--- a/nibiru/msg/spot.py
+++ b/nibiru/msg/spot.py
@@ -18,7 +18,6 @@ class MsgsSpot:
 
     @staticmethod
     def create_pool(
-        creator: str,
         swap_fee: float,
         exit_fee: float,
         a: int,
@@ -26,7 +25,6 @@ class MsgsSpot:
         assets: List[PoolAsset],
     ) -> 'MsgCreatePool':
         return MsgCreatePool(
-            creator=creator,
             swap_fee=swap_fee,
             exit_fee=exit_fee,
             a=a,
@@ -36,29 +34,25 @@ class MsgsSpot:
 
     @staticmethod
     def join_pool(
-        sender: str,
         pool_id: int,
         tokens: Union[Coin, List[Coin]],
     ) -> 'MsgJoinPool':
-        return MsgJoinPool(sender=sender, pool_id=pool_id, tokens=tokens)
+        return MsgJoinPool(pool_id=pool_id, tokens=tokens)
 
     @staticmethod
     def exit_pool(
-        sender: str,
         pool_id: int,
         pool_shares: Coin,
     ) -> 'MsgExitPool':
-        return MsgExitPool(sender=sender, pool_id=pool_id, pool_shares=pool_shares)
+        return MsgExitPool(pool_id=pool_id, pool_shares=pool_shares)
 
     @staticmethod
     def swap(
-        sender: str,
         pool_id: int,
         token_in: Coin,
         token_out_denom: str,
     ) -> 'MsgSwapAssets':
         return MsgSwapAssets(
-            sender=sender,
             pool_id=pool_id,
             token_in=token_in,
             token_out_denom=token_out_denom,
@@ -71,20 +65,18 @@ class MsgCreatePool(PythonMsg):
     Create a pool using the assets specified
 
     Attributes:
-        creator (str): The creator address
         swap_fee (float): The swap fee required for the pool
         exit_fee (float): The exit fee required for the pool
         assets (List[PoolAsset]): The assets to compose the pool
     """
 
-    creator: str
     swap_fee: float
     exit_fee: float
     a: int
     pool_type: PoolType
     assets: List[PoolAsset]
 
-    def to_pb(self) -> pb.MsgCreatePool:
+    def to_pb(self, sender: str) -> pb.MsgCreatePool:
         """
         Returns the Message as protobuf object.
 
@@ -93,9 +85,7 @@ class MsgCreatePool(PythonMsg):
 
         """
         pool_assets = [
-            pool_tx_pb.PoolAsset(
-                token=a.token._generate_proto_object(), weight=str(int(a.weight * 1e6))
-            )
+            pool_tx_pb.PoolAsset(token=a.token.to_pb(), weight=str(int(a.weight * 1e6)))
             for a in self.assets
         ]
 
@@ -103,7 +93,7 @@ class MsgCreatePool(PythonMsg):
         exit_fee_dec = str(int(self.exit_fee * 1e18))
 
         return pb.MsgCreatePool(
-            creator=self.creator,
+            creator=sender,
             pool_params=pool_tx_pb.PoolParams(
                 swap_fee=swap_fee_dec,
                 exit_fee=exit_fee_dec,
@@ -120,16 +110,14 @@ class MsgJoinPool(PythonMsg):
     Join a pool using the specified tokens
 
     Attributes:
-        sender (str): The creator address
         pool_id (int): The id of the pool to join
         tokens (List[Coin]): The tokens to be bonded in the pool
     """
 
-    sender: str
     pool_id: int
     tokens: Union[Coin, List[Coin]]
 
-    def to_pb(self) -> pb.MsgJoinPool:
+    def to_pb(self, sender: str) -> pb.MsgJoinPool:
         """
         Returns the Message as protobuf object.
 
@@ -140,9 +128,9 @@ class MsgJoinPool(PythonMsg):
         if isinstance(self.tokens, Coin):
             self.tokens = [self.tokens]
         return pb.MsgJoinPool(
-            sender=self.sender,
+            sender=sender,
             pool_id=self.pool_id,
-            tokens_in=[token._generate_proto_object() for token in self.tokens],
+            tokens_in=[token.to_pb() for token in self.tokens],
         )
 
 
@@ -152,16 +140,14 @@ class MsgExitPool(PythonMsg):
     Exit a pool using the specified pool shares
 
     Attributes:
-        sender (str): The creator address
         pool_id (int): The id of the pool
         pool_shares (Coin): The tokens as share of the pool to exit with
     """
 
-    sender: str
     pool_id: int
     pool_shares: Coin
 
-    def to_pb(self) -> pb.MsgExitPool:
+    def to_pb(self, sender: str) -> pb.MsgExitPool:
         """
         Returns the Message as protobuf object.
 
@@ -170,9 +156,9 @@ class MsgExitPool(PythonMsg):
 
         """
         return pb.MsgExitPool(
-            sender=self.sender,
+            sender=sender,
             pool_id=self.pool_id,
-            pool_shares=self.pool_shares._generate_proto_object(),
+            pool_shares=self.pool_shares.to_pb(),
         )
 
 
@@ -182,18 +168,16 @@ class MsgSwapAssets(PythonMsg):
     Swap the assets provided for the denom specified
 
     Attributes:
-        sender (str): The creator address
         pool_id (int): The id of the pool
         token_in (Coin): The token in we wish to swap with
         token_out_denom (str): The token we expect out of the pool
     """
 
-    sender: str
     pool_id: int
     token_in: Coin
     token_out_denom: str
 
-    def to_pb(self) -> pb.MsgSwapAssets:
+    def to_pb(self, sender: str) -> pb.MsgSwapAssets:
         """
         Returns the Message as protobuf object.
 
@@ -202,9 +186,9 @@ class MsgSwapAssets(PythonMsg):
 
         """
         return pb.MsgSwapAssets(
-            sender=self.sender,
+            sender=sender,
             pool_id=self.pool_id,
-            token_in=self.token_in._generate_proto_object(),
+            token_in=self.token_in.to_pb(),
             token_out_denom=self.token_out_denom,
         )
 

--- a/nibiru/msg/staking.py
+++ b/nibiru/msg/staking.py
@@ -17,7 +17,6 @@ class MsgsStaking:
 
     @staticmethod
     def delegate(
-        delegator_address: str,
         validator_address: str,
         amount: float,
     ) -> 'MsgDelegate':
@@ -25,7 +24,6 @@ class MsgsStaking:
         Delegate tokens to a validator
 
         Attributes:
-            delegator_address: str
             validator_address: str
             amount: float
 
@@ -33,14 +31,12 @@ class MsgsStaking:
             MsgDelegate: PythonMsg for type 'cosmos.staking.v1beta1.MsgDelegate'
         """
         return MsgDelegate(
-            delegator_address=delegator_address,
             validator_address=validator_address,
             amount=amount,
         )
 
     @staticmethod
     def undelegate(
-        delegator_address: str,
         validator_address: str,
         amount: float,
     ) -> 'MsgUndelegate':
@@ -48,34 +44,28 @@ class MsgsStaking:
         Undelegate tokens from a validator
 
         Attributes:
-            delegator_address (str): Bech32 address for the delegator
             validator_address (str): Bech32 valoper address
             amount (float): Amount of unibi to undelegate.
         """
         return MsgUndelegate(
-            delegator_address=delegator_address,
             validator_address=validator_address,
             amount=amount,
         )
 
     @staticmethod
     def withdraw_delegator_reward(
-        delegator_address: str,
         validator_address: str,
     ) -> 'MsgWithdrawDelegatorReward':
         """TODO
         Withdraw the reward from a validator
 
         Attributes:
-            delegator_address (str)
             validator_address (str)
 
         Returns:
             MsgWithdrawDelegatorReward: _description_
         """
-        return MsgWithdrawDelegatorReward(
-            delegator_address=delegator_address, validator_address=validator_address
-        )
+        return MsgWithdrawDelegatorReward(validator_address=validator_address)
 
 
 @dataclasses.dataclass
@@ -84,16 +74,14 @@ class MsgDelegate(PythonMsg):
     Delegate tokens to a validator
 
     Attributes:
-        delegator_address: str
         validator_address: str
         amount: float
     """
 
-    delegator_address: str
     validator_address: str
     amount: float
 
-    def to_pb(self) -> pb_staking.MsgDelegate:
+    def to_pb(self, sender: str) -> pb_staking.MsgDelegate:
         """
         Returns the Message as protobuf object.
 
@@ -102,9 +90,9 @@ class MsgDelegate(PythonMsg):
 
         """
         return pb_staking.MsgDelegate(
-            delegator_address=self.delegator_address,
+            delegator_address=sender,
             validator_address=self.validator_address,
-            amount=Coin(self.amount, "unibi")._generate_proto_object(),
+            amount=Coin(self.amount, "unibi").to_pb(),
         )
 
 
@@ -114,16 +102,14 @@ class MsgUndelegate(PythonMsg):
     Undelegate tokens from a validator
 
     Attributes:
-        delegator_address: str
         validator_address: str
         amount: float
     """
 
-    delegator_address: str
     validator_address: str
     amount: float
 
-    def to_pb(self) -> pb_staking.MsgUndelegate:
+    def to_pb(self, sender: str) -> pb_staking.MsgUndelegate:
         """
         Returns the Message as protobuf object.
 
@@ -132,9 +118,9 @@ class MsgUndelegate(PythonMsg):
 
         """
         return pb_staking.MsgUndelegate(
-            delegator_address=self.delegator_address,
+            delegator_address=sender,
             validator_address=self.validator_address,
-            amount=Coin(self.amount, "unibi")._generate_proto_object(),
+            amount=Coin(self.amount, "unibi").to_pb(),
         )
 
 
@@ -144,14 +130,12 @@ class MsgWithdrawDelegatorReward(PythonMsg):
     Withdraw the reward from a validator
 
     Attributes:
-        delegator_address (str)
         validator_address (str)
     """
 
-    delegator_address: str
     validator_address: str
 
-    def to_pb(self) -> pb_distribution.MsgWithdrawDelegatorReward:
+    def to_pb(self, sender: str) -> pb_distribution.MsgWithdrawDelegatorReward:
         """
         Returns the Message as protobuf object.
 
@@ -160,6 +144,6 @@ class MsgWithdrawDelegatorReward(PythonMsg):
 
         """
         return pb_distribution.MsgWithdrawDelegatorReward(
-            delegator_address=self.delegator_address,
+            delegator_address=sender,
             validator_address=self.validator_address,
         )

--- a/nibiru/pytypes/common.py
+++ b/nibiru/pytypes/common.py
@@ -53,7 +53,7 @@ class Coin:
     amount: float
     denom: str
 
-    def _generate_proto_object(self):
+    def to_pb(self):
         """
 
         Returns:
@@ -103,7 +103,7 @@ TX_CONFIG_ATTRS: List[str] = [
 
 class PythonMsg(abc.ABC):
     @abc.abstractmethod
-    def to_pb(self) -> nibiru.ProtobufMessage:
+    def to_pb(self, sender: str) -> nibiru.ProtobufMessage:
         """
         Generate the protobuf message
 

--- a/nibiru/query_clients/spot.py
+++ b/nibiru/query_clients/spot.py
@@ -273,7 +273,7 @@ class SpotQueryClient(QueryClient):
             api_callable=self.api.EstimateSwapExactAmountIn,
             req=spot_type.QuerySwapExactAmountInRequest(
                 pool_id=pool_id,
-                token_in=token_in._generate_proto_object(),
+                token_in=token_in.to_pb(),
                 token_out_denom=token_out_denom,
             ),
             should_deserialize=False,
@@ -310,9 +310,7 @@ class SpotQueryClient(QueryClient):
             api_callable=self.api.EstimateJoinExactAmountIn,
             req=spot_type.QueryJoinExactAmountInRequest(
                 pool_id=pool_id,
-                tokens_in=[
-                    tokens_in._generate_proto_object() for tokens_in in tokens_ins
-                ],
+                tokens_in=[tokens_in.to_pb() for tokens_in in tokens_ins],
             ),
             should_deserialize=False,
         )

--- a/nibiru/tx.py
+++ b/nibiru/tx.py
@@ -96,17 +96,13 @@ class TxClient:
         """
 
         tx: Transaction
-        # address: wallet.Address = self.ensure_address_info()
-        tx, address = self.build_tx(
-            msgs=msgs,
-        )
+        tx, address = self.build_tx(msgs=msgs)
 
         # Validate account sequence
         if sequence is None:
             sequence = address.sequence
         sequence_err: str = "sequence was not given or available on the wallet object."
         assert address, sequence_err
-        # assert sequence, sequence_err
 
         tx = tx.with_sequence(sequence=sequence)
 
@@ -281,7 +277,6 @@ class TxClient:
         if not isinstance(msgs, list):
             msgs = [msgs]
 
-        pb_msgs = [msg.to_pb() for msg in msgs]
         self.client.sync_timeout_height()
 
         address: wallet.Address
@@ -294,6 +289,8 @@ class TxClient:
 
         if sequence is None:
             sequence = self.address.sequence
+
+        pb_msgs = [msg.to_pb(sender=address.to_acc_bech32()) for msg in msgs]
 
         tx = (
             Transaction()

--- a/tests/bank_test.py
+++ b/tests/bank_test.py
@@ -14,12 +14,10 @@ def test_send_multiple_msgs(client_validator, client_new_user):
     tx_output = client_validator.tx.execute_msgs(
         msgs=[
             nibiru.Msg.bank.send(
-                client_validator.address,
                 client_new_user.address,
                 [Coin(7, "unibi"), Coin(70, "unusd")],
             ),
             nibiru.Msg.bank.send(
-                client_validator.address,
                 client_new_user.address,
                 [Coin(15, "unibi"), Coin(23, "unusd")],
             ),
@@ -43,7 +41,6 @@ def test_send_single_msg(client_validator, client_new_user):
     tx_output = client_validator.tx.execute_msgs(
         [
             nibiru.Msg.bank.send(
-                client_validator.address,
                 client_new_user.address,
                 [Coin(10, "unibi"), Coin(10, "unusd")],
             ),

--- a/tests/broadcast_test.py
+++ b/tests/broadcast_test.py
@@ -89,12 +89,10 @@ def test_do_BroadcastTxSync():
     tx, _ = client_validator.tx.build_tx(
         msgs=[
             bank.MsgsBank.send(
-                client_validator.address,
                 client_new_user.address,
                 [pytypes.Coin(7, "unibi"), pytypes.Coin(70, "unusd")],
             ),
             bank.MsgsBank.send(
-                client_validator.address,
                 client_new_user.address,
                 [pytypes.Coin(15, "unibi"), pytypes.Coin(23, "unusd")],
             ),

--- a/tests/perp_test.py
+++ b/tests/perp_test.py
@@ -25,7 +25,6 @@ def test_open_position(client_validator):
     try:
         tx_output: pt.ExecuteTxResp = client_validator.tx.execute_msgs(
             Msg.perp.open_position(
-                sender=client_validator.address,
                 pair=PAIR,
                 is_long=False,
                 quote_asset_amount=10,
@@ -147,7 +146,6 @@ def test_perp_add_margin(client_validator):
         # Transaction add_margin must succeed
         tx_output = client_validator.tx.execute_msgs(
             Msg.perp.add_margin(
-                sender=client_validator.address,
                 pair=PAIR,
                 margin=pt.Coin(10, "unusd"),
             ),
@@ -169,7 +167,6 @@ def test_perp_remove_margin(client_validator):
     try:
         tx_output = client_validator.tx.execute_msgs(
             Msg.perp.remove_margin(
-                sender=client_validator.address,
                 pair=PAIR,
                 margin=pt.Coin(2, "unusd"),
             )
@@ -189,9 +186,7 @@ def test_perp_close_posititon(client_validator):
 
     try:
         # Transaction close_position must succeed
-        tx_output = client_validator.tx.execute_msgs(
-            Msg.perp.close_position(sender=client_validator.address, pair=PAIR)
-        )
+        tx_output = client_validator.tx.execute_msgs(Msg.perp.close_position(pair=PAIR))
         tests.broadcast_tx_must_succeed(res=tx_output)
 
         out = client_validator.query.perp.position(

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -27,7 +27,6 @@ def test_spot_create_pool(client_validator: ChainClient):
     try:
         tx_output = client_validator.tx.execute_msgs(
             nibiru.Msg.spot.create_pool(
-                creator=client_validator.address,
                 swap_fee=0.01,
                 exit_fee=0.02,
                 assets=[

--- a/tests/staking_test.py
+++ b/tests/staking_test.py
@@ -17,7 +17,6 @@ def delegate(client_validator: ChainClient):
     return client_validator.tx.execute_msgs(
         [
             Msg.staking.delegate(
-                delegator_address=client_validator.address,
                 validator_address=get_validator_operator_address(client_validator),
                 amount=1,
             ),
@@ -29,7 +28,6 @@ def undelegate(client_validator: ChainClient):
     return client_validator.tx.execute_msgs(
         [
             Msg.staking.undelegate(
-                delegator_address=client_validator.address,
                 validator_address=get_validator_operator_address(client_validator),
                 amount=1,
             ),

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -89,7 +89,6 @@ def test_get_block_messages(
 ):
     out: pytypes.ExecuteTxResp = client_validator.tx.execute_msgs(
         nibiru.Msg.bank.send(
-            client_validator.address,
             client_new_user.address,
             [Coin(10000, "unibi"), Coin(100, "unusd")],
         )


### PR DESCRIPTION
Sender of TX is just an authenticated user - you can't customize it. So now it's taken from the user address.